### PR TITLE
Auth Update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,4 @@ type:
 qa:
 	make lint
 	make type
-	make tests
+	make test

--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,5 @@ type:
 qa:
 	make lint
 	make type
-	make test
+	# TODO: re-enable this once we have the org environment set up
+	# make test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ license = {file = "LICENSE"}
 readme = "README.md"
 requires-python = ">= 3.8.1"
 dependencies = [
-    "guardrails-ai>=0.4.0",
+    "guardrails-ai>=0.4.2",
     "litellm"
 ]
 


### PR DESCRIPTION
This PR uses the `api_key` kwarg from the context store if the litellm model is from openai.

Related to guardrails-ai/validator-hub-ui#9

This will allow users to provide their own credentials when using the hub playground.